### PR TITLE
Rename "Fingerprint Pro Server API" to "Fingerprint Server API"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <a href="https://discord.gg/39EpE2neBg"><img src="https://img.shields.io/discord/852099967190433792?style=logo&label=Discord&logo=Discord&logoColor=white" alt="Discord server"></a>
 </p>
 
-# Fingerprint Pro Server Python SDK
+# Fingerprint Server Python SDK
 
 [Fingerprint](https://fingerprint.com) is a device intelligence platform offering 99.5% accurate visitor identification.
 The Fingerprint Server Python SDK is an easy way to interact with the Fingerprint [Server API](https://dev.fingerprint.com/reference/pro-server-api) from your Python application. You can retrieve visitor history or individual identification events.

--- a/contributing.md
+++ b/contributing.md
@@ -1,4 +1,4 @@
-# Contributing to Fingerprint Pro Server API SDK
+# Contributing to Fingerprint Server API SDK
 
 ## Structure
 

--- a/fingerprint_pro_server_api_sdk/__init__.py
+++ b/fingerprint_pro_server_api_sdk/__init__.py
@@ -3,9 +3,9 @@
 # flake8: noqa
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/api/fingerprint_api.py
+++ b/fingerprint_pro_server_api_sdk/api/fingerprint_api.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/api_client.py
+++ b/fingerprint_pro_server_api_sdk/api_client.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/configuration.py
+++ b/fingerprint_pro_server_api_sdk/configuration.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/__init__.py
+++ b/fingerprint_pro_server_api_sdk/models/__init__.py
@@ -2,9 +2,9 @@
 
 # flake8: noqa
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/botd.py
+++ b/fingerprint_pro_server_api_sdk/models/botd.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/botd_bot.py
+++ b/fingerprint_pro_server_api_sdk/models/botd_bot.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/botd_bot_result.py
+++ b/fingerprint_pro_server_api_sdk/models/botd_bot_result.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/browser_details.py
+++ b/fingerprint_pro_server_api_sdk/models/browser_details.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/cloned_app.py
+++ b/fingerprint_pro_server_api_sdk/models/cloned_app.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/deprecated_geolocation.py
+++ b/fingerprint_pro_server_api_sdk/models/deprecated_geolocation.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/developer_tools.py
+++ b/fingerprint_pro_server_api_sdk/models/developer_tools.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/emulator.py
+++ b/fingerprint_pro_server_api_sdk/models/emulator.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/error.py
+++ b/fingerprint_pro_server_api_sdk/models/error.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/error_code.py
+++ b/fingerprint_pro_server_api_sdk/models/error_code.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/error_plain_response.py
+++ b/fingerprint_pro_server_api_sdk/models/error_plain_response.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/error_response.py
+++ b/fingerprint_pro_server_api_sdk/models/error_response.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/events_get_response.py
+++ b/fingerprint_pro_server_api_sdk/models/events_get_response.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/events_update_request.py
+++ b/fingerprint_pro_server_api_sdk/models/events_update_request.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/factory_reset.py
+++ b/fingerprint_pro_server_api_sdk/models/factory_reset.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/frida.py
+++ b/fingerprint_pro_server_api_sdk/models/frida.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/geolocation.py
+++ b/fingerprint_pro_server_api_sdk/models/geolocation.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/geolocation_city.py
+++ b/fingerprint_pro_server_api_sdk/models/geolocation_city.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/geolocation_continent.py
+++ b/fingerprint_pro_server_api_sdk/models/geolocation_continent.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/geolocation_country.py
+++ b/fingerprint_pro_server_api_sdk/models/geolocation_country.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/geolocation_subdivision.py
+++ b/fingerprint_pro_server_api_sdk/models/geolocation_subdivision.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/geolocation_subdivisions.py
+++ b/fingerprint_pro_server_api_sdk/models/geolocation_subdivisions.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/high_activity.py
+++ b/fingerprint_pro_server_api_sdk/models/high_activity.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/identification.py
+++ b/fingerprint_pro_server_api_sdk/models/identification.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/identification_confidence.py
+++ b/fingerprint_pro_server_api_sdk/models/identification_confidence.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/identification_seen_at.py
+++ b/fingerprint_pro_server_api_sdk/models/identification_seen_at.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/incognito.py
+++ b/fingerprint_pro_server_api_sdk/models/incognito.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/ip_blocklist.py
+++ b/fingerprint_pro_server_api_sdk/models/ip_blocklist.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/ip_blocklist_details.py
+++ b/fingerprint_pro_server_api_sdk/models/ip_blocklist_details.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/ip_info.py
+++ b/fingerprint_pro_server_api_sdk/models/ip_info.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/ip_info_asn.py
+++ b/fingerprint_pro_server_api_sdk/models/ip_info_asn.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/ip_info_data_center.py
+++ b/fingerprint_pro_server_api_sdk/models/ip_info_data_center.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/ip_info_v4.py
+++ b/fingerprint_pro_server_api_sdk/models/ip_info_v4.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/ip_info_v6.py
+++ b/fingerprint_pro_server_api_sdk/models/ip_info_v6.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/jailbroken.py
+++ b/fingerprint_pro_server_api_sdk/models/jailbroken.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/location_spoofing.py
+++ b/fingerprint_pro_server_api_sdk/models/location_spoofing.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/mit_m_attack.py
+++ b/fingerprint_pro_server_api_sdk/models/mit_m_attack.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/privacy_settings.py
+++ b/fingerprint_pro_server_api_sdk/models/privacy_settings.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_botd.py
+++ b/fingerprint_pro_server_api_sdk/models/product_botd.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_cloned_app.py
+++ b/fingerprint_pro_server_api_sdk/models/product_cloned_app.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_developer_tools.py
+++ b/fingerprint_pro_server_api_sdk/models/product_developer_tools.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_emulator.py
+++ b/fingerprint_pro_server_api_sdk/models/product_emulator.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_factory_reset.py
+++ b/fingerprint_pro_server_api_sdk/models/product_factory_reset.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_frida.py
+++ b/fingerprint_pro_server_api_sdk/models/product_frida.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_high_activity.py
+++ b/fingerprint_pro_server_api_sdk/models/product_high_activity.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_identification.py
+++ b/fingerprint_pro_server_api_sdk/models/product_identification.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_incognito.py
+++ b/fingerprint_pro_server_api_sdk/models/product_incognito.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_ip_blocklist.py
+++ b/fingerprint_pro_server_api_sdk/models/product_ip_blocklist.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_ip_info.py
+++ b/fingerprint_pro_server_api_sdk/models/product_ip_info.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_jailbroken.py
+++ b/fingerprint_pro_server_api_sdk/models/product_jailbroken.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_location_spoofing.py
+++ b/fingerprint_pro_server_api_sdk/models/product_location_spoofing.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_mit_m_attack.py
+++ b/fingerprint_pro_server_api_sdk/models/product_mit_m_attack.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_privacy_settings.py
+++ b/fingerprint_pro_server_api_sdk/models/product_privacy_settings.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_proxy.py
+++ b/fingerprint_pro_server_api_sdk/models/product_proxy.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_raw_device_attributes.py
+++ b/fingerprint_pro_server_api_sdk/models/product_raw_device_attributes.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_remote_control.py
+++ b/fingerprint_pro_server_api_sdk/models/product_remote_control.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_root_apps.py
+++ b/fingerprint_pro_server_api_sdk/models/product_root_apps.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_suspect_score.py
+++ b/fingerprint_pro_server_api_sdk/models/product_suspect_score.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_tampering.py
+++ b/fingerprint_pro_server_api_sdk/models/product_tampering.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_tor.py
+++ b/fingerprint_pro_server_api_sdk/models/product_tor.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_velocity.py
+++ b/fingerprint_pro_server_api_sdk/models/product_velocity.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_virtual_machine.py
+++ b/fingerprint_pro_server_api_sdk/models/product_virtual_machine.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/product_vpn.py
+++ b/fingerprint_pro_server_api_sdk/models/product_vpn.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/products.py
+++ b/fingerprint_pro_server_api_sdk/models/products.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/proxy.py
+++ b/fingerprint_pro_server_api_sdk/models/proxy.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/raw_device_attribute.py
+++ b/fingerprint_pro_server_api_sdk/models/raw_device_attribute.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/raw_device_attribute_error.py
+++ b/fingerprint_pro_server_api_sdk/models/raw_device_attribute_error.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/raw_device_attributes.py
+++ b/fingerprint_pro_server_api_sdk/models/raw_device_attributes.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/related_visitor.py
+++ b/fingerprint_pro_server_api_sdk/models/related_visitor.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/related_visitors_response.py
+++ b/fingerprint_pro_server_api_sdk/models/related_visitors_response.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/remote_control.py
+++ b/fingerprint_pro_server_api_sdk/models/remote_control.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/root_apps.py
+++ b/fingerprint_pro_server_api_sdk/models/root_apps.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/search_events_response.py
+++ b/fingerprint_pro_server_api_sdk/models/search_events_response.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/search_events_response_events.py
+++ b/fingerprint_pro_server_api_sdk/models/search_events_response_events.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/suspect_score.py
+++ b/fingerprint_pro_server_api_sdk/models/suspect_score.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/tag.py
+++ b/fingerprint_pro_server_api_sdk/models/tag.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/tampering.py
+++ b/fingerprint_pro_server_api_sdk/models/tampering.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/tor.py
+++ b/fingerprint_pro_server_api_sdk/models/tor.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/velocity.py
+++ b/fingerprint_pro_server_api_sdk/models/velocity.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/velocity_data.py
+++ b/fingerprint_pro_server_api_sdk/models/velocity_data.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/velocity_intervals.py
+++ b/fingerprint_pro_server_api_sdk/models/velocity_intervals.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/virtual_machine.py
+++ b/fingerprint_pro_server_api_sdk/models/virtual_machine.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/visit.py
+++ b/fingerprint_pro_server_api_sdk/models/visit.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/visitors_get_response.py
+++ b/fingerprint_pro_server_api_sdk/models/visitors_get_response.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/vpn.py
+++ b/fingerprint_pro_server_api_sdk/models/vpn.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/vpn_confidence.py
+++ b/fingerprint_pro_server_api_sdk/models/vpn_confidence.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/vpn_methods.py
+++ b/fingerprint_pro_server_api_sdk/models/vpn_methods.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_cloned_app.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_cloned_app.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_developer_tools.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_developer_tools.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_emulator.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_emulator.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_factory_reset.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_factory_reset.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_frida.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_frida.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_high_activity.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_high_activity.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_ip_blocklist.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_ip_blocklist.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_ip_info.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_ip_info.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_jailbroken.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_jailbroken.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_location_spoofing.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_location_spoofing.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_mit_m_attack.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_mit_m_attack.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_privacy_settings.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_privacy_settings.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_proxy.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_proxy.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_raw_device_attributes.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_raw_device_attributes.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_remote_control.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_remote_control.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_root_apps.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_root_apps.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_suspect_score.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_suspect_score.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_tampering.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_tampering.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_tor.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_tor.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_velocity.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_velocity.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_virtual_machine.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_virtual_machine.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/models/webhook_vpn.py
+++ b/fingerprint_pro_server_api_sdk/models/webhook_vpn.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/fingerprint_pro_server_api_sdk/rest.py
+++ b/fingerprint_pro_server_api_sdk/rest.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/res/fingerprint-server-api.yaml
+++ b/res/fingerprint-server-api.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.3
 info:
-  title: Fingerprint Pro Server API
+  title: Fingerprint Server API
   description: >
-    Fingerprint Pro Server API allows you to get information about visitors and
+    Fingerprint Server API allows you to get information about visitors and
     about individual events in a server environment. It can be used for data
     exports, decision-making, and data analysis scenarios.
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device.   # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com
@@ -38,7 +38,7 @@ long_description = re.sub(r"(?P<prefix>\[[^]]*]\()(?P<postfix>docs/[^)]*\))", '\
 
 setup(
     name=NAME,
-    description="Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device. ",
+    description="Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. It can be used for data exports, decision-making, and data analysis scenarios. Server API is intended for server-side usage, it's not intended to be used from the client side, whether it's a browser or a mobile device. ",
     long_description=long_description,
     long_description_content_type='text/markdown',
     license="MIT",
@@ -50,7 +50,7 @@ setup(
         "Code": "https://github.com/fingerprintjs/fingerprint-pro-server-api-python-sdk",
         "Issue Tracker": "https://github.com/fingerprintjs/fingerprint-pro-server-api-python-sdk/issues",
     },
-    keywords=["Swagger", "Fingerprint Pro Server API", "browser", "detection", "fingerprint", "identification",
+    keywords=["Swagger", "Fingerprint Server API", "browser", "detection", "fingerprint", "identification",
               "fingerprinting", "browser-fingerprinting", "browser-fingerprint", "fraud-detection", "fraud",
               "audio-fingerprinting", "fingerprintjs", "fingerprintjs-pro", "visitor-identifier"],
     install_requires=REQUIRES,

--- a/template/README.mustache
+++ b/template/README.mustache
@@ -17,7 +17,7 @@
   <a href="https://discord.gg/39EpE2neBg"><img src="https://img.shields.io/discord/852099967190433792?style=logo&label=Discord&logo=Discord&logoColor=white" alt="Discord server"></a>
 </p>
 
-# Fingerprint Pro Server Python SDK
+# Fingerprint Server Python SDK
 
 [Fingerprint](https://fingerprint.com) is a device intelligence platform offering 99.5% accurate visitor identification.
 The Fingerprint Server Python SDK is an easy way to interact with the Fingerprint [Server API](https://dev.fingerprint.com/reference/pro-server-api) from your Python application. You can retrieve visitor history or individual identification events.

--- a/test/test_fingerprint_api.py
+++ b/test/test_fingerprint_api.py
@@ -1,9 +1,9 @@
 # coding: utf-8
 
 """
-    Fingerprint Pro Server API
+    Fingerprint Server API
 
-    Fingerprint Pro Server API allows you to get information about visitors and about individual events in a server environment. This API can be used for data exports, decision-making, and data analysis scenarios.  # noqa: E501
+    Fingerprint Server API allows you to get information about visitors and about individual events in a server environment. This API can be used for data exports, decision-making, and data analysis scenarios.  # noqa: E501
 
     OpenAPI spec version: 3
     Contact: support@fingerprint.com

--- a/update_event_example.py
+++ b/update_event_example.py
@@ -8,7 +8,7 @@ from fingerprint_pro_server_api_sdk.models import EventsUpdateRequest
 from dotenv import load_dotenv
 
 load_dotenv()
-parser = argparse.ArgumentParser(description='Update an event in the Fingerprint Pro Server API')
+parser = argparse.ArgumentParser(description='Update an event in the Fingerprint Server API')
 parser.add_argument('--linked_id', type=str)
 parser.add_argument('--tag', type=str)
 parser.add_argument('--suspect', type=bool)


### PR DESCRIPTION
Updated documentation and code comments to reflect the new naming convention. Replaced all instances of `Fingerprint Pro Server API` with `Fingerprint Server API`.

Related-Task: INTER-1240