### PR TITLE
Upgrade `setuptools` and `cryptography` dependencies

### DIFF
--- a/.changeset/rotten-turtles-give.md
+++ b/.changeset/rotten-turtles-give.md
@@ -1,0 +1,5 @@
+---
+"@fingerprint/python-sdk": patch
+---
+
+Bump minimum required `cryptography` version from `41.0.0` to `46.0.5`.

--- a/fingerprint_server_sdk/sealed.py
+++ b/fingerprint_server_sdk/sealed.py
@@ -1,7 +1,6 @@
 import json
 import zlib
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from fingerprint_server_sdk.models.event import Event
@@ -92,9 +91,7 @@ def __unseal_aes256gcm(sealed_data: bytes, decryption_key: bytes) -> str:
 
     ciphertext = sealed_data[len(SEALED_HEADER) + nonce_length : -auth_tag_length]
 
-    decipher = Cipher(
-        algorithms.AES(decryption_key), modes.GCM(nonce, auth_tag), backend=default_backend()
-    ).decryptor()
+    decipher = Cipher(algorithms.AES(decryption_key), modes.GCM(nonce, auth_tag)).decryptor()
 
     compressed = decipher.update(ciphertext) + decipher.finalize()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ python-dotenv = ">= 1.0.0"
 
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=82.0.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.pylint.'MESSAGES CONTROL']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   "python-dateutil (>=2.8.2)",
   "pydantic (>=2)",
   "typing-extensions (>=4.7.1)",
-  "cryptography"
+  "cryptography (>=46.0.5)"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ python_dateutil >= 2.8.2
 pydantic >= 2
 typing-extensions >= 4.7.1
 cryptography >= 41.0.0
-setuptools >= 65.5.1
+setuptools >= 82.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ urllib3 >= 2.1.0, < 3.0.0
 python_dateutil >= 2.8.2
 pydantic >= 2
 typing-extensions >= 4.7.1
-cryptography >= 41.0.0
+cryptography >= 46.0.5
 setuptools >= 82.0.1

--- a/template/pyproject.mustache
+++ b/template/pyproject.mustache
@@ -56,7 +56,7 @@ typing-extensions = ">= 4.7.1"
 {{#lazyImports}}
 lazy-imports = ">= 1, < 2"
 {{/lazyImports}}
-cryptography = ">= 41.0.0"
+cryptography = ">= 46.0.5"
 python-dotenv = ">= 1.0.0"
 {{/poetry1}}
 {{^poetry1}}
@@ -86,7 +86,7 @@ dependencies = [
 {{#lazyImports}}
   "lazy-imports (>=1,<2)"
 {{/lazyImports}}
-  "cryptography"
+  "cryptography (>=46.0.5)"
 ]
 
 [project.optional-dependencies]

--- a/template/pyproject.mustache
+++ b/template/pyproject.mustache
@@ -118,7 +118,7 @@ python-dotenv = ">= 1.0.0"
 
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=82.0.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.pylint.'MESSAGES CONTROL']

--- a/template/requirements.mustache
+++ b/template/requirements.mustache
@@ -21,5 +21,5 @@ typing-extensions >= 4.7.1
 {{#lazyImports}}
 lazy-imports >= 1, < 2
 {{/lazyImports}}
-cryptography >= 41.0.0
+cryptography >= 46.0.5
 setuptools >= 82.0.1

--- a/template/requirements.mustache
+++ b/template/requirements.mustache
@@ -22,4 +22,4 @@ typing-extensions >= 4.7.1
 lazy-imports >= 1, < 2
 {{/lazyImports}}
 cryptography >= 41.0.0
-setuptools >= 65.5.1
+setuptools >= 82.0.1

--- a/template/sealed.py.mustache
+++ b/template/sealed.py.mustache
@@ -1,7 +1,6 @@
 import json
 import zlib
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from {{packageName}}.models.event import Event
@@ -91,8 +90,7 @@ def __unseal_aes256gcm(sealed_data: bytes, decryption_key: bytes) -> str:
 
     decipher = Cipher(
         algorithms.AES(decryption_key),
-        modes.GCM(nonce, auth_tag),
-        backend=default_backend()
+        modes.GCM(nonce, auth_tag)
     ).decryptor()
 
     compressed = decipher.update(ciphertext) + decipher.finalize()


### PR DESCRIPTION
### Summary

- Bump `setuptools` minimum from `65.5.1` to `82.0.1` ([full changelog](https://github.com/pypa/setuptools/compare/v65.5.1...v82.0.1))
- Bump `cryptography` minimum from `41.0.0` to `46.0.5` ([full changelog](https://github.com/pyca/cryptography/compare/41.0.0...46.0.5))
- Remove deprecated `default_backend()` usage from `sealed.py`

### Patched Vulnerabilities (cryptography)

| CVE | Affected Versions | Minimum Fix |
|-----|-------------------|-------------|
| [CVE-2024-6119][cve-2024-6119] | `37.0.0` - `43.0.0` | `43.0.1` |
| [GHSA-79v4-65xg-pq4g][ghsa-79v4-65xg-pq4g] | `42.0.0` - `44.0.0` | `44.0.1` |
| [CVE-2026-26007][cve-2026-26007] | `<= 46.0.4` | ✅  `46.0.5` |

[cve-2024-6119]: https://github.com/pyca/cryptography/security/advisories/GHSA-h4gh-qq45-vh27
[ghsa-79v4-65xg-pq4g]: https://github.com/pyca/cryptography/security/advisories/GHSA-79v4-65xg-pq4g
[cve-2026-26007]: https://github.com/pyca/cryptography/security/advisories/GHSA-r6ph-v2qm-q3c2