### PR TITLE
INTER-1920: Correct SDK identifier prefix

### DIFF
--- a/.changeset/neat-horses-swim.md
+++ b/.changeset/neat-horses-swim.md
@@ -1,0 +1,5 @@
+---
+"@fingerprint/python-sdk": patch
+---
+
+Fix incorrect SDK name in the integration info parameter

--- a/fingerprint_server_sdk/api_client.py
+++ b/fingerprint_server_sdk/api_client.py
@@ -87,7 +87,7 @@ class ApiClient:
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = f'fingerprint-server-python-sdk/{__version__}'
+        self.user_agent = f'fingerprint-pro-server-python-sdk/{__version__}'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self) -> ApiClient:

--- a/fingerprint_server_sdk/configuration.py
+++ b/fingerprint_server_sdk/configuration.py
@@ -184,7 +184,7 @@ class Configuration:
         self.default_query_params: list[tuple[str, str]] = (
             default_query_params
             if default_query_params
-            else [('ii', f'fingerprint-server-python-sdk/{__version__}')]
+            else [('ii', f'fingerprint-pro-server-python-sdk/{__version__}')]
         )
 
     def __deepcopy__(self, memo: dict[int, Any]) -> Self:

--- a/template/api_client.mustache
+++ b/template/api_client.mustache
@@ -79,7 +79,7 @@ class ApiClient:
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = {{#httpUserAgent}}'{{{httpUserAgent}}}'{{/httpUserAgent}}{{^httpUserAgent}}f'fingerprint-server-python-sdk/{__version__}'{{/httpUserAgent}}
+        self.user_agent = {{#httpUserAgent}}'{{{httpUserAgent}}}'{{/httpUserAgent}}{{^httpUserAgent}}f'fingerprint-pro-server-python-sdk/{__version__}'{{/httpUserAgent}}
         self.client_side_validation = configuration.client_side_validation
 
 {{#async}}

--- a/template/configuration.mustache
+++ b/template/configuration.mustache
@@ -214,7 +214,7 @@ class Configuration:
         self.default_query_params: list[tuple[str, str]] = (
             default_query_params
             if default_query_params
-            else [("ii", f"fingerprint-server-python-sdk/{__version__}")]
+            else [("ii", f"fingerprint-pro-server-python-sdk/{__version__}")]
         )
 
     def __deepcopy__(self, memo:  dict[int, Any]) -> Self:

--- a/test/mock_pool_manager.py
+++ b/test/mock_pool_manager.py
@@ -37,7 +37,7 @@ class MockPoolManager:
 
         url, ii_value = self._strip_query_param(args[1], 'ii')
         self._tc.assertIsInstance(ii_value, str)
-        self._tc.assertEqual(f'fingerprint-server-python-sdk/{__version__}', ii_value)
+        self._tc.assertEqual(f'fingerprint-pro-server-python-sdk/{__version__}', ii_value)
         self._tc.assertEqual(request_url, url)
 
         self._tc.assertEqual(set(request_config.keys()), set(kwargs.keys()))

--- a/test/test_fingerprint_api.py
+++ b/test/test_fingerprint_api.py
@@ -28,12 +28,12 @@ class TestFingerprintApi(unittest.TestCase):
 
     def setUp(self) -> None:
         configuration = Configuration(api_key=API_KEY, region=REGION)
-        self.integration_info = ('ii', f'fingerprint-server-python-sdk/{__version__}')
+        self.integration_info = ('ii', f'fingerprint-pro-server-python-sdk/{__version__}')
         self.request_headers = {
             'Content-Type': 'application/json',
             'Authorization': f'Bearer {API_KEY}',
             'Accept': 'application/json',
-            'User-Agent': f'fingerprint-server-python-sdk/{__version__}',
+            'User-Agent': f'fingerprint-pro-server-python-sdk/{__version__}',
         }
         self.api = FingerprintApi(configuration)
 


### PR DESCRIPTION
Add missing `pro` to the SDK identifiers, changing in the integration info (`ii`) query parameter and `User-Agent` header.