### PR TITLE
chore: install ruff inside generate.sh INTER-2002

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -33,5 +33,6 @@ docker run --rm -u "$(id -u):$(id -g)" -v "${PWD}:/local" -w /local "openapitool
 
 # Linting and formatting
 PYTHON_CMD="${PYTHON:-$(command -v python3 || command -v python)}"
+"$PYTHON_CMD" -m pip install --quiet 'ruff==0.15.0'
 "$PYTHON_CMD" -m ruff format .
 "$PYTHON_CMD" -m ruff check --fix --unsafe-fixes .


### PR DESCRIPTION
## Summary
The external sync workflow in `fingerprint-pro-server-api-openapi` invokes `bash ./generate.sh` with only `actions/setup-python` in the environment, so `ruff` is not preinstalled and the script fails with `No module named ruff`. This makes `generate.sh` self-contained by installing ruff itself, so callers don't need to know to install it first.

Pinned to `0.15.0` to match the dev-dep in `pyproject.toml`.

## Failure
https://github.com/fingerprintjs/fingerprint-pro-server-api-openapi/actions/runs/24790520856 — Python job.

## Test plan
- [x] Ran `bash ./generate.sh` end-to-end in a clean venv (docker + pip install + ruff format + ruff check) locally
- [ ] Re-run the [Sync Server-Side SDKs schema](https://github.com/fingerprintjs/fingerprint-pro-server-api-openapi/actions/workflows/sync-server-side-sdks-schema.yml) workflow after merge to confirm the Python job succeeds