### PR TITLE
chore: add support for non-discriminator, oneOf query parameters

### DIFF
--- a/template/api.mustache
+++ b/template/api.mustache
@@ -16,7 +16,7 @@ from typing_extensions import Annotated
 {{#-first}}
 from {{packageName}}.models.{{#lambda.snakecase}}{{schema.complexType}}{{/lambda.snakecase}} import {{schema.complexType}}
 {{! 
-Workaround for missing imports for parmaeters that use a oneOf with a nested datetime.
+Workaround for missing imports for parameters that use a oneOf with a nested datetime.
 The ruff check autofix will remove this import if it is unused
 }}
 from datetime import datetime, date

--- a/template/api.mustache
+++ b/template/api.mustache
@@ -167,7 +167,7 @@ class {{classname}}:
                 _query_params.append(
                     (
                         '{{schema.baseName}}',
-                        {{paramName}}.replace(tzinfo={{paramName}}.tzinfo or timezone.utc).isoformat(timespec='microseconds')
+                        {{paramName}}.isoformat(timespec='microseconds')
                     )
                 )
             elif isinstance({{paramName}}, date):

--- a/template/api.mustache
+++ b/template/api.mustache
@@ -15,7 +15,7 @@ from typing_extensions import Annotated
 {{#composedSchemas.oneOf}}
 {{#-first}}
 from {{packageName}}.models.{{#lambda.snakecase}}{{schema.complexType}}{{/lambda.snakecase}} import {{schema.complexType}}
-from datetime import datetime, date
+from datetime import datetime, date, timezone
 {{/-first}}
 {{/composedSchemas.oneOf}}
 {{/hasDiscriminatorWithNonEmptyMapping}}
@@ -167,18 +167,14 @@ class {{classname}}:
                 _query_params.append(
                     (
                         '{{schema.baseName}}',
-                        {{paramName}}.strftime(
-                            self.api_client.configuration.datetime_format
-                        )
+                        {{paramName}}.replace(tzinfo={{paramName}}.tzinfo or timezone.utc).isoformat(timespec='microseconds')
                     )
                 )
             elif isinstance({{paramName}}, date):
                 _query_params.append(
                     (
                         '{{schema.baseName}}',
-                        {{paramName}}.strftime(
-                            self.api_client.configuration.date_format
-                        )
+                        {{paramName}}.isoformat()
                     )
                 )
             else:

--- a/template/api.mustache
+++ b/template/api.mustache
@@ -14,7 +14,7 @@ from typing_extensions import Annotated
 {{^hasDiscriminatorWithNonEmptyMapping}}
 {{#composedSchemas.oneOf}}
 {{#-first}}
-from {{packageName}}.models import {{schema.complexType}}
+from {{packageName}}.models.{{#lambda.snakecase}}{{schema.complexType}}{{/lambda.snakecase}} import {{schema.complexType}}
 {{! 
 Workaround for missing imports for parmaeters that use a oneOf with a nested datetime.
 The ruff check autofix will remove this import if it is unused

--- a/template/api.mustache
+++ b/template/api.mustache
@@ -8,6 +8,23 @@ from typing_extensions import Annotated
 {{#imports}}
 {{import}}
 {{/imports}}
+{{#operations.operation}}
+{{! Workaround for missing imports for parameters that use oneOf }}
+{{#allParams}}
+{{^hasDiscriminatorWithNonEmptyMapping}}
+{{#composedSchemas.oneOf}}
+{{#-first}}
+from {{packageName}} import {{schema.complexType}}
+{{! 
+Workaround for missing imports for parmaeters that use a oneOf with a nested datetime.
+The ruff check autofix will remove this import if it is unused
+}}
+from datetime import datetime, date
+{{/-first}}
+{{/composedSchemas.oneOf}}
+{{/hasDiscriminatorWithNonEmptyMapping}}
+{{/allParams}}
+{{/operations.operation}}
 from {{packageName}}.api_client import ApiClient, RequestSerialized
 from {{packageName}}.api_response import ApiResponse
 from {{packageName}}.configuration import Configuration
@@ -117,6 +134,7 @@ class {{classname}}:
 {{#queryParams}}
         # process the query parameters
         if {{paramName}} is not None:
+            {{^schema.composedSchemas.oneOf}}
             {{#isDateTime}}
             if isinstance({{paramName}}, datetime):
                 _query_params.append(
@@ -146,6 +164,31 @@ class {{classname}}:
             {{^isDateTime}}{{^isDate}}
             _query_params.append(('{{baseName}}', {{paramName}}{{#isEnumRef}}.value{{/isEnumRef}}))
             {{/isDate}}{{/isDateTime}}
+            {{/schema.composedSchemas.oneOf}}
+            {{#schema.composedSchemas.oneOf}}
+            {{#-first}}
+            if isinstance({{paramName}}, datetime):
+                _query_params.append(
+                    (
+                        '{{schema.baseName}}',
+                        {{paramName}}.strftime(
+                            self.api_client.configuration.datetime_format
+                        )
+                    )
+                )
+            elif isinstance({{paramName}}, date):
+                _query_params.append(
+                    (
+                        '{{schema.baseName}}',
+                        {{paramName}}.strftime(
+                            self.api_client.configuration.date_format
+                        )
+                    )
+                )
+            else:
+                _query_params.append(('{{schema.baseName}}', {{paramName}}))
+            {{/-first}}
+            {{/schema.composedSchemas.oneOf}}
 {{/queryParams}}
 
 {{#headerParams}}

--- a/template/api.mustache
+++ b/template/api.mustache
@@ -15,10 +15,6 @@ from typing_extensions import Annotated
 {{#composedSchemas.oneOf}}
 {{#-first}}
 from {{packageName}}.models.{{#lambda.snakecase}}{{schema.complexType}}{{/lambda.snakecase}} import {{schema.complexType}}
-{{! 
-Workaround for missing imports for parameters that use a oneOf with a nested datetime.
-The ruff check autofix will remove this import if it is unused
-}}
 from datetime import datetime, date
 {{/-first}}
 {{/composedSchemas.oneOf}}

--- a/template/api.mustache
+++ b/template/api.mustache
@@ -14,7 +14,7 @@ from typing_extensions import Annotated
 {{^hasDiscriminatorWithNonEmptyMapping}}
 {{#composedSchemas.oneOf}}
 {{#-first}}
-from {{packageName}} import {{schema.complexType}}
+from {{packageName}}.models import {{schema.complexType}}
 {{! 
 Workaround for missing imports for parmaeters that use a oneOf with a nested datetime.
 The ruff check autofix will remove this import if it is unused

--- a/template/model_doc.mustache
+++ b/template/model_doc.mustache
@@ -11,6 +11,17 @@ Name | Type | Description | Notes
 {{#vars}}**{{name}}** | {{#isPrimitiveType}}**{{dataType}}**{{/isPrimitiveType}}{{^isPrimitiveType}}[**{{dataType}}**]({{complexType}}.md){{/isPrimitiveType}} | {{{description}}} | {{^required}}[optional] {{/required}}{{#isReadOnly}}[readonly] {{/isReadOnly}}{{#defaultValue}}[default to {{{.}}}]{{/defaultValue}}
 {{/vars}}
 {{/emptyVars}}
+{{#emptyVars}}
+{{^model.discriminator}}
+{{#composedSchemas.oneOf}}
+{{#-first}}
+## Type alias
+
+`Union[{{#oneOf}}{{^-last}}{{.}},{{/-last}}{{#-last}}{{.}}{{/-last}}{{/oneOf}}]`
+{{/-first}}
+{{/composedSchemas.oneOf}}
+{{/model.discriminator}}
+{{/emptyVars}}
 {{/isEnum}}
 {{#isEnum}}
 ## Enum

--- a/template/model_oneof.mustache
+++ b/template/model_oneof.mustache
@@ -1,3 +1,4 @@
+{{#hasDiscriminatorWithNonEmptyMapping}}
 from __future__ import annotations
 import json
 import pprint
@@ -206,3 +207,13 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 # TODO: Rewrite to not use raise_errors
 {{classname}}.model_rebuild(raise_errors=False)
 {{/vendorExtensions.x-py-postponed-model-imports.size}}
+{{/hasDiscriminatorWithNonEmptyMapping}}
+{{^hasDiscriminatorWithNonEmptyMapping}}
+from typing import Union
+{{#composedSchemas.oneOf}}
+{{#isDateTime}}
+from datetime import datetime
+{{/isDateTime}}
+{{/composedSchemas.oneOf}}
+{{classname}} = Union[{{#oneOf}}{{^-last}}{{.}},{{/-last}}{{#-last}}{{.}}{{/-last}}{{/oneOf}}]
+{{/hasDiscriminatorWithNonEmptyMapping}}

--- a/template/model_oneof.mustache
+++ b/template/model_oneof.mustache
@@ -212,8 +212,8 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 from typing import Union
 {{#composedSchemas.oneOf}}
 {{#isDateTime}}
-from datetime import datetime
+from pydantic import AwareDatetime
 {{/isDateTime}}
 {{/composedSchemas.oneOf}}
-{{classname}} = Union[{{#oneOf}}{{^-last}}{{.}},{{/-last}}{{#-last}}{{.}}{{/-last}}{{/oneOf}}]
+{{classname}} = Union[{{#composedSchemas.oneOf}}{{#isDateTime}}AwareDatetime{{/isDateTime}}{{^isDateTime}}{{dataType}}{{/isDateTime}}{{^-last}},{{/-last}}{{/composedSchemas.oneOf}}]
 {{/hasDiscriminatorWithNonEmptyMapping}}

--- a/template/partial_api_args.mustache
+++ b/template/partial_api_args.mustache
@@ -1,7 +1,7 @@
 (
         self,
         {{#allParams}}
-        {{paramName}}: {{{vendorExtensions.x-py-typing}}}{{^required}} = None{{/required}},
+        {{paramName}}: {{^schema.composedSchemas}}{{{vendorExtensions.x-py-typing}}}{{/schema.composedSchemas}}{{#schema.composedSchemas}}Annotated[{{^required}}Optional[{{/required}}{{schema.complexType}}{{^required}}]{{/required}},Field(description="{{{description}}}",)]{{/schema.composedSchemas}}{{^required}} = None{{/required}},
         {{/allParams}}
         _request_timeout: Union[
             None,


### PR DESCRIPTION
This PR updates the handling for `oneOf` constructs that do not use a discriminator to allow query parameters to use a union type to expand the accepted types for a parameter without breaking backward compatibility. This functionality will be used for the pending changes to expand `start` and `end` to accept a `date-time` `string`.

These template updates do not add JSON serialization and deserialization support for the generated type alias for a union type because that functionality is not yet needed.

Itemized changes:
- Update `model_oneof.mustache` to generate a type alias rather than a container class when a `oneOf` construct does not use a discriminator. This allows additional types to be used for query parameters without breaking backward compatibility.
- Update `partial_api_args.mustache` to generate type annotations for parameters that use `oneOf` construct without a discriminator.
- Update `api.mustache` to handle query parameters that use a union type when their schema is a `oneOf` construct without a discriminator.
- Update `model_doc.mustache` to document that a `oneOf` construct without a discriminator is a type alias.

See #191 for the code generated after these template updates and the schema is updated to use a `oneOf` for `start` and `end`.


