### PR TITLE
INTER-2250: Accept unknown enum values

### DIFF
--- a/.changeset/accept-unknown-enum-values.md
+++ b/.changeset/accept-unknown-enum-values.md
@@ -1,0 +1,5 @@
+---
+'@fingerprint/python-sdk': patch
+---
+
+Accept unknown enum values gracefully instead of throwing errors during deserialization

--- a/fingerprint_server_sdk/api_client.py
+++ b/fingerprint_server_sdk/api_client.py
@@ -739,10 +739,8 @@ class ApiClient:
         """
         try:
             return klass(data)
-        except ValueError as err:
-            raise ApiException(
-                status=0, reason=(f'Failed to parse `{data}` as `{klass}`')
-            ) from err
+        except ValueError:
+            return data
 
     def __deserialize_model(self, data: Any, klass: Any) -> Any:
         """Deserializes list or dict to model.

--- a/fingerprint_server_sdk/api_client.py
+++ b/fingerprint_server_sdk/api_client.py
@@ -737,7 +737,12 @@ class ApiClient:
         :param klass: class literal.
         :return: enum value.
         """
-        return klass(data)
+        try:
+            return klass(data)
+        except ValueError as err:
+            raise ApiException(
+                status=0, reason=(f'Failed to parse `{data}` as `{klass}`')
+            ) from err
 
     def __deserialize_model(self, data: Any, klass: Any) -> Any:
         """Deserializes list or dict to model.

--- a/fingerprint_server_sdk/api_client.py
+++ b/fingerprint_server_sdk/api_client.py
@@ -730,17 +730,17 @@ class ApiClient:
                 status=0, reason=(f'Failed to parse `{string}` as datetime object')
             ) from err
 
-    def __deserialize_enum(self, data: Any, klass: type[Enum]) -> Enum:
+    def __deserialize_enum(self, data: Any, klass: type[Enum]) -> Union[Enum, str]:
         """Deserializes primitive type to enum.
 
         :param data: primitive type.
         :param klass: class literal.
-        :return: enum value.
+        :return: enum value or raw string if the value is unknown.
         """
         try:
             return klass(data)
         except ValueError:
-            return data
+            return str(data)
 
     def __deserialize_model(self, data: Any, klass: Any) -> Any:
         """Deserializes list or dict to model.

--- a/fingerprint_server_sdk/api_client.py
+++ b/fingerprint_server_sdk/api_client.py
@@ -730,17 +730,14 @@ class ApiClient:
                 status=0, reason=(f'Failed to parse `{string}` as datetime object')
             ) from err
 
-    def __deserialize_enum(self, data: Any, klass: type[Enum]) -> Union[Enum, str]:
+    def __deserialize_enum(self, data: Any, klass: type[Enum]) -> Enum:
         """Deserializes primitive type to enum.
 
         :param data: primitive type.
         :param klass: class literal.
-        :return: enum value or raw string if the value is unknown.
+        :return: enum value.
         """
-        try:
-            return klass(data)
-        except ValueError:
-            return str(data)
+        return klass(data)
 
     def __deserialize_model(self, data: Any, klass: Any) -> Any:
         """Deserializes list or dict to model.

--- a/fingerprint_server_sdk/models/bot_info.py
+++ b/fingerprint_server_sdk/models/bot_info.py
@@ -48,17 +48,11 @@ class BotInfo(BaseModel):
     @field_validator('identity')
     def identity_validate_enum(cls, value: Any) -> Any:
         """Validates the enum"""
-        if value not in set(['verified', 'signed', 'spoofed', 'unknown']):
-            raise ValueError(
-                "must be one of enum values ('verified', 'signed', 'spoofed', 'unknown')"
-            )
         return value
 
     @field_validator('confidence')
     def confidence_validate_enum(cls, value: Any) -> Any:
         """Validates the enum"""
-        if value not in set(['low', 'medium', 'high']):
-            raise ValueError("must be one of enum values ('low', 'medium', 'high')")
         return value
 
     model_config = ConfigDict(

--- a/fingerprint_server_sdk/models/bot_info.py
+++ b/fingerprint_server_sdk/models/bot_info.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 from typing import Any, ClassVar, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing_extensions import Self
 
 
@@ -44,16 +44,6 @@ class BotInfo(BaseModel):
         'identity',
         'confidence',
     ]
-
-    @field_validator('identity')
-    def identity_validate_enum(cls, value: Any) -> Any:
-        """Validates the enum"""
-        return value
-
-    @field_validator('confidence')
-    def confidence_validate_enum(cls, value: Any) -> Any:
-        """Validates the enum"""
-        return value
 
     model_config = ConfigDict(
         populate_by_name=True,

--- a/fingerprint_server_sdk/models/bot_info_category.py
+++ b/fingerprint_server_sdk/models/bot_info_category.py
@@ -47,3 +47,11 @@ class BotInfoCategory(str, Enum):
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of BotInfoCategory from a JSON string"""
         return cls(json.loads(json_str))
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Accept unknown enum values gracefully."""
+        obj = str.__new__(cls, value)
+        obj._name_ = str(value)
+        obj._value_ = value
+        return obj

--- a/fingerprint_server_sdk/models/bot_info_category.py
+++ b/fingerprint_server_sdk/models/bot_info_category.py
@@ -51,9 +51,10 @@ class BotInfoCategory(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        typed_value = str(value)
-        obj = str.__new__(cls, typed_value)
-        obj._name_ = typed_value
-        obj._value_ = typed_value
-        cls._value2member_map_[typed_value] = obj
+        if not isinstance(value, str):
+            raise ValueError(f'{value!r} is not a valid {cls.__name__}')
+        obj = str.__new__(cls, value)
+        obj._name_ = value
+        obj._value_ = value
+        cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/bot_info_category.py
+++ b/fingerprint_server_sdk/models/bot_info_category.py
@@ -54,7 +54,7 @@ class BotInfoCategory(str, Enum):
         if not isinstance(value, str):
             raise ValueError(f'{value!r} is not a valid {cls.__name__}')
         obj = str.__new__(cls, value)
-        obj._name_ = value
+        obj._name_ = str(value)
         obj._value_ = value
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/bot_info_category.py
+++ b/fingerprint_server_sdk/models/bot_info_category.py
@@ -51,7 +51,9 @@ class BotInfoCategory(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        obj = str.__new__(cls, value)
-        obj._name_ = str(value)
-        obj._value_ = value
+        typed_value = str(value)
+        obj = str.__new__(cls, typed_value)
+        obj._name_ = typed_value
+        obj._value_ = typed_value
+        cls._value2member_map_[typed_value] = obj
         return obj

--- a/fingerprint_server_sdk/models/bot_info_category.py
+++ b/fingerprint_server_sdk/models/bot_info_category.py
@@ -56,5 +56,6 @@ class BotInfoCategory(str, Enum):
         obj = str.__new__(cls, value)
         obj._name_ = str(value)
         obj._value_ = value
+        # cache it so the same value won't trigger `_missing_` again
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/bot_info_confidence.py
+++ b/fingerprint_server_sdk/models/bot_info_confidence.py
@@ -38,9 +38,10 @@ class BotInfoConfidence(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        typed_value = str(value)
-        obj = str.__new__(cls, typed_value)
-        obj._name_ = typed_value
-        obj._value_ = typed_value
-        cls._value2member_map_[typed_value] = obj
+        if not isinstance(value, str):
+            raise ValueError(f'{value!r} is not a valid {cls.__name__}')
+        obj = str.__new__(cls, value)
+        obj._name_ = value
+        obj._value_ = value
+        cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/bot_info_confidence.py
+++ b/fingerprint_server_sdk/models/bot_info_confidence.py
@@ -34,3 +34,11 @@ class BotInfoConfidence(str, Enum):
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of BotInfoConfidence from a JSON string"""
         return cls(json.loads(json_str))
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Accept unknown enum values gracefully."""
+        obj = str.__new__(cls, value)
+        obj._name_ = str(value)
+        obj._value_ = value
+        return obj

--- a/fingerprint_server_sdk/models/bot_info_confidence.py
+++ b/fingerprint_server_sdk/models/bot_info_confidence.py
@@ -43,5 +43,6 @@ class BotInfoConfidence(str, Enum):
         obj = str.__new__(cls, value)
         obj._name_ = str(value)
         obj._value_ = value
+        # cache it so the same value won't trigger `_missing_` again
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/bot_info_confidence.py
+++ b/fingerprint_server_sdk/models/bot_info_confidence.py
@@ -41,7 +41,7 @@ class BotInfoConfidence(str, Enum):
         if not isinstance(value, str):
             raise ValueError(f'{value!r} is not a valid {cls.__name__}')
         obj = str.__new__(cls, value)
-        obj._name_ = value
+        obj._name_ = str(value)
         obj._value_ = value
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/bot_info_confidence.py
+++ b/fingerprint_server_sdk/models/bot_info_confidence.py
@@ -38,7 +38,9 @@ class BotInfoConfidence(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        obj = str.__new__(cls, value)
-        obj._name_ = str(value)
-        obj._value_ = value
+        typed_value = str(value)
+        obj = str.__new__(cls, typed_value)
+        obj._name_ = typed_value
+        obj._value_ = typed_value
+        cls._value2member_map_[typed_value] = obj
         return obj

--- a/fingerprint_server_sdk/models/bot_info_identity.py
+++ b/fingerprint_server_sdk/models/bot_info_identity.py
@@ -35,3 +35,11 @@ class BotInfoIdentity(str, Enum):
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of BotInfoIdentity from a JSON string"""
         return cls(json.loads(json_str))
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Accept unknown enum values gracefully."""
+        obj = str.__new__(cls, value)
+        obj._name_ = str(value)
+        obj._value_ = value
+        return obj

--- a/fingerprint_server_sdk/models/bot_info_identity.py
+++ b/fingerprint_server_sdk/models/bot_info_identity.py
@@ -44,5 +44,6 @@ class BotInfoIdentity(str, Enum):
         obj = str.__new__(cls, value)
         obj._name_ = str(value)
         obj._value_ = value
+        # cache it so the same value won't trigger `_missing_` again
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/bot_info_identity.py
+++ b/fingerprint_server_sdk/models/bot_info_identity.py
@@ -42,7 +42,7 @@ class BotInfoIdentity(str, Enum):
         if not isinstance(value, str):
             raise ValueError(f'{value!r} is not a valid {cls.__name__}')
         obj = str.__new__(cls, value)
-        obj._name_ = value
+        obj._name_ = str(value)
         obj._value_ = value
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/bot_info_identity.py
+++ b/fingerprint_server_sdk/models/bot_info_identity.py
@@ -39,9 +39,10 @@ class BotInfoIdentity(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        typed_value = str(value)
-        obj = str.__new__(cls, typed_value)
-        obj._name_ = typed_value
-        obj._value_ = typed_value
-        cls._value2member_map_[typed_value] = obj
+        if not isinstance(value, str):
+            raise ValueError(f'{value!r} is not a valid {cls.__name__}')
+        obj = str.__new__(cls, value)
+        obj._name_ = value
+        obj._value_ = value
+        cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/bot_info_identity.py
+++ b/fingerprint_server_sdk/models/bot_info_identity.py
@@ -39,7 +39,9 @@ class BotInfoIdentity(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        obj = str.__new__(cls, value)
-        obj._name_ = str(value)
-        obj._value_ = value
+        typed_value = str(value)
+        obj = str.__new__(cls, typed_value)
+        obj._name_ = typed_value
+        obj._value_ = typed_value
+        cls._value2member_map_[typed_value] = obj
         return obj

--- a/fingerprint_server_sdk/models/bot_result.py
+++ b/fingerprint_server_sdk/models/bot_result.py
@@ -38,9 +38,10 @@ class BotResult(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        typed_value = str(value)
-        obj = str.__new__(cls, typed_value)
-        obj._name_ = typed_value
-        obj._value_ = typed_value
-        cls._value2member_map_[typed_value] = obj
+        if not isinstance(value, str):
+            raise ValueError(f'{value!r} is not a valid {cls.__name__}')
+        obj = str.__new__(cls, value)
+        obj._name_ = value
+        obj._value_ = value
+        cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/bot_result.py
+++ b/fingerprint_server_sdk/models/bot_result.py
@@ -38,7 +38,9 @@ class BotResult(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        obj = str.__new__(cls, value)
-        obj._name_ = str(value)
-        obj._value_ = value
+        typed_value = str(value)
+        obj = str.__new__(cls, typed_value)
+        obj._name_ = typed_value
+        obj._value_ = typed_value
+        cls._value2member_map_[typed_value] = obj
         return obj

--- a/fingerprint_server_sdk/models/bot_result.py
+++ b/fingerprint_server_sdk/models/bot_result.py
@@ -43,5 +43,6 @@ class BotResult(str, Enum):
         obj = str.__new__(cls, value)
         obj._name_ = str(value)
         obj._value_ = value
+        # cache it so the same value won't trigger `_missing_` again
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/bot_result.py
+++ b/fingerprint_server_sdk/models/bot_result.py
@@ -34,3 +34,11 @@ class BotResult(str, Enum):
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of BotResult from a JSON string"""
         return cls(json.loads(json_str))
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Accept unknown enum values gracefully."""
+        obj = str.__new__(cls, value)
+        obj._name_ = str(value)
+        obj._value_ = value
+        return obj

--- a/fingerprint_server_sdk/models/bot_result.py
+++ b/fingerprint_server_sdk/models/bot_result.py
@@ -41,7 +41,7 @@ class BotResult(str, Enum):
         if not isinstance(value, str):
             raise ValueError(f'{value!r} is not a valid {cls.__name__}')
         obj = str.__new__(cls, value)
-        obj._name_ = value
+        obj._name_ = str(value)
         obj._value_ = value
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/error_code.py
+++ b/fingerprint_server_sdk/models/error_code.py
@@ -49,3 +49,11 @@ class ErrorCode(str, Enum):
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of ErrorCode from a JSON string"""
         return cls(json.loads(json_str))
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Accept unknown enum values gracefully."""
+        obj = str.__new__(cls, value)
+        obj._name_ = str(value)
+        obj._value_ = value
+        return obj

--- a/fingerprint_server_sdk/models/error_code.py
+++ b/fingerprint_server_sdk/models/error_code.py
@@ -56,7 +56,7 @@ class ErrorCode(str, Enum):
         if not isinstance(value, str):
             raise ValueError(f'{value!r} is not a valid {cls.__name__}')
         obj = str.__new__(cls, value)
-        obj._name_ = value
+        obj._name_ = str(value)
         obj._value_ = value
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/error_code.py
+++ b/fingerprint_server_sdk/models/error_code.py
@@ -53,7 +53,9 @@ class ErrorCode(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        obj = str.__new__(cls, value)
-        obj._name_ = str(value)
-        obj._value_ = value
+        typed_value = str(value)
+        obj = str.__new__(cls, typed_value)
+        obj._name_ = typed_value
+        obj._value_ = typed_value
+        cls._value2member_map_[typed_value] = obj
         return obj

--- a/fingerprint_server_sdk/models/error_code.py
+++ b/fingerprint_server_sdk/models/error_code.py
@@ -58,5 +58,6 @@ class ErrorCode(str, Enum):
         obj = str.__new__(cls, value)
         obj._name_ = str(value)
         obj._value_ = value
+        # cache it so the same value won't trigger `_missing_` again
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/error_code.py
+++ b/fingerprint_server_sdk/models/error_code.py
@@ -53,9 +53,10 @@ class ErrorCode(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        typed_value = str(value)
-        obj = str.__new__(cls, typed_value)
-        obj._name_ = typed_value
-        obj._value_ = typed_value
-        cls._value2member_map_[typed_value] = obj
+        if not isinstance(value, str):
+            raise ValueError(f'{value!r} is not a valid {cls.__name__}')
+        obj = str.__new__(cls, value)
+        obj._name_ = value
+        obj._value_ = value
+        cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/incremental_identification_status.py
+++ b/fingerprint_server_sdk/models/incremental_identification_status.py
@@ -33,3 +33,11 @@ class IncrementalIdentificationStatus(str, Enum):
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of IncrementalIdentificationStatus from a JSON string"""
         return cls(json.loads(json_str))
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Accept unknown enum values gracefully."""
+        obj = str.__new__(cls, value)
+        obj._name_ = str(value)
+        obj._value_ = value
+        return obj

--- a/fingerprint_server_sdk/models/incremental_identification_status.py
+++ b/fingerprint_server_sdk/models/incremental_identification_status.py
@@ -37,9 +37,10 @@ class IncrementalIdentificationStatus(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        typed_value = str(value)
-        obj = str.__new__(cls, typed_value)
-        obj._name_ = typed_value
-        obj._value_ = typed_value
-        cls._value2member_map_[typed_value] = obj
+        if not isinstance(value, str):
+            raise ValueError(f'{value!r} is not a valid {cls.__name__}')
+        obj = str.__new__(cls, value)
+        obj._name_ = value
+        obj._value_ = value
+        cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/incremental_identification_status.py
+++ b/fingerprint_server_sdk/models/incremental_identification_status.py
@@ -37,7 +37,9 @@ class IncrementalIdentificationStatus(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        obj = str.__new__(cls, value)
-        obj._name_ = str(value)
-        obj._value_ = value
+        typed_value = str(value)
+        obj = str.__new__(cls, typed_value)
+        obj._name_ = typed_value
+        obj._value_ = typed_value
+        cls._value2member_map_[typed_value] = obj
         return obj

--- a/fingerprint_server_sdk/models/incremental_identification_status.py
+++ b/fingerprint_server_sdk/models/incremental_identification_status.py
@@ -40,7 +40,7 @@ class IncrementalIdentificationStatus(str, Enum):
         if not isinstance(value, str):
             raise ValueError(f'{value!r} is not a valid {cls.__name__}')
         obj = str.__new__(cls, value)
-        obj._name_ = value
+        obj._name_ = str(value)
         obj._value_ = value
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/incremental_identification_status.py
+++ b/fingerprint_server_sdk/models/incremental_identification_status.py
@@ -42,5 +42,6 @@ class IncrementalIdentificationStatus(str, Enum):
         obj = str.__new__(cls, value)
         obj._name_ = str(value)
         obj._value_ = value
+        # cache it so the same value won't trigger `_missing_` again
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/proximity.py
+++ b/fingerprint_server_sdk/models/proximity.py
@@ -43,10 +43,6 @@ class Proximity(BaseModel):
     @field_validator('precision_radius')
     def precision_radius_validate_enum(cls, value: Any) -> Any:
         """Validates the enum"""
-        if value not in set([10, 25, 65, 175, 450, 1200, 3300, 8500, 22500]):
-            raise ValueError(
-                'must be one of enum values (10, 25, 65, 175, 450, 1200, 3300, 8500, 22500)'
-            )
         return value
 
     model_config = ConfigDict(

--- a/fingerprint_server_sdk/models/proximity.py
+++ b/fingerprint_server_sdk/models/proximity.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 from typing import Annotated, Any, ClassVar, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 from typing_extensions import Self
 
 
@@ -39,11 +39,6 @@ class Proximity(BaseModel):
         description='A value between `0` and `1` representing the likelihood that the true device location lies within the mapped proximity zone.   * Scores closer to `1` indicate high confidence that the location is inside the mapped proximity zone.   * Scores closer to `0` indicate lower confidence, suggesting the true location may fall in an adjacent zone. '
     )
     __properties: ClassVar[list[str]] = ['id', 'precision_radius', 'confidence']
-
-    @field_validator('precision_radius')
-    def precision_radius_validate_enum(cls, value: Any) -> Any:
-        """Validates the enum"""
-        return value
 
     model_config = ConfigDict(
         populate_by_name=True,

--- a/fingerprint_server_sdk/models/proxy_confidence.py
+++ b/fingerprint_server_sdk/models/proxy_confidence.py
@@ -41,7 +41,7 @@ class ProxyConfidence(str, Enum):
         if not isinstance(value, str):
             raise ValueError(f'{value!r} is not a valid {cls.__name__}')
         obj = str.__new__(cls, value)
-        obj._name_ = value
+        obj._name_ = str(value)
         obj._value_ = value
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/proxy_confidence.py
+++ b/fingerprint_server_sdk/models/proxy_confidence.py
@@ -38,9 +38,10 @@ class ProxyConfidence(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        typed_value = str(value)
-        obj = str.__new__(cls, typed_value)
-        obj._name_ = typed_value
-        obj._value_ = typed_value
-        cls._value2member_map_[typed_value] = obj
+        if not isinstance(value, str):
+            raise ValueError(f'{value!r} is not a valid {cls.__name__}')
+        obj = str.__new__(cls, value)
+        obj._name_ = value
+        obj._value_ = value
+        cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/proxy_confidence.py
+++ b/fingerprint_server_sdk/models/proxy_confidence.py
@@ -38,7 +38,9 @@ class ProxyConfidence(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        obj = str.__new__(cls, value)
-        obj._name_ = str(value)
-        obj._value_ = value
+        typed_value = str(value)
+        obj = str.__new__(cls, typed_value)
+        obj._name_ = typed_value
+        obj._value_ = typed_value
+        cls._value2member_map_[typed_value] = obj
         return obj

--- a/fingerprint_server_sdk/models/proxy_confidence.py
+++ b/fingerprint_server_sdk/models/proxy_confidence.py
@@ -43,5 +43,6 @@ class ProxyConfidence(str, Enum):
         obj = str.__new__(cls, value)
         obj._name_ = str(value)
         obj._value_ = value
+        # cache it so the same value won't trigger `_missing_` again
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/proxy_confidence.py
+++ b/fingerprint_server_sdk/models/proxy_confidence.py
@@ -34,3 +34,11 @@ class ProxyConfidence(str, Enum):
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of ProxyConfidence from a JSON string"""
         return cls(json.loads(json_str))
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Accept unknown enum values gracefully."""
+        obj = str.__new__(cls, value)
+        obj._name_ = str(value)
+        obj._value_ = value
+        return obj

--- a/fingerprint_server_sdk/models/proxy_details.py
+++ b/fingerprint_server_sdk/models/proxy_details.py
@@ -42,8 +42,6 @@ class ProxyDetails(BaseModel):
     @field_validator('proxy_type')
     def proxy_type_validate_enum(cls, value: Any) -> Any:
         """Validates the enum"""
-        if value not in set(['residential', 'data_center']):
-            raise ValueError("must be one of enum values ('residential', 'data_center')")
         return value
 
     model_config = ConfigDict(

--- a/fingerprint_server_sdk/models/proxy_details.py
+++ b/fingerprint_server_sdk/models/proxy_details.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 from typing import Any, ClassVar, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 from typing_extensions import Self
 
 
@@ -38,11 +38,6 @@ class ProxyDetails(BaseModel):
         description='String representing the last proxy service provider detected when this IP was synced. An IP can be shared by multiple service providers. ',
     )
     __properties: ClassVar[list[str]] = ['proxy_type', 'last_seen_at', 'provider']
-
-    @field_validator('proxy_type')
-    def proxy_type_validate_enum(cls, value: Any) -> Any:
-        """Validates the enum"""
-        return value
 
     model_config = ConfigDict(
         populate_by_name=True,

--- a/fingerprint_server_sdk/models/rare_device_percentile_bucket.py
+++ b/fingerprint_server_sdk/models/rare_device_percentile_bucket.py
@@ -46,5 +46,6 @@ class RareDevicePercentileBucket(str, Enum):
         obj = str.__new__(cls, value)
         obj._name_ = str(value)
         obj._value_ = value
+        # cache it so the same value won't trigger `_missing_` again
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/rare_device_percentile_bucket.py
+++ b/fingerprint_server_sdk/models/rare_device_percentile_bucket.py
@@ -41,7 +41,9 @@ class RareDevicePercentileBucket(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        obj = str.__new__(cls, value)
-        obj._name_ = str(value)
-        obj._value_ = value
+        typed_value = str(value)
+        obj = str.__new__(cls, typed_value)
+        obj._name_ = typed_value
+        obj._value_ = typed_value
+        cls._value2member_map_[typed_value] = obj
         return obj

--- a/fingerprint_server_sdk/models/rare_device_percentile_bucket.py
+++ b/fingerprint_server_sdk/models/rare_device_percentile_bucket.py
@@ -37,3 +37,11 @@ class RareDevicePercentileBucket(str, Enum):
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of RareDevicePercentileBucket from a JSON string"""
         return cls(json.loads(json_str))
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Accept unknown enum values gracefully."""
+        obj = str.__new__(cls, value)
+        obj._name_ = str(value)
+        obj._value_ = value
+        return obj

--- a/fingerprint_server_sdk/models/rare_device_percentile_bucket.py
+++ b/fingerprint_server_sdk/models/rare_device_percentile_bucket.py
@@ -41,9 +41,10 @@ class RareDevicePercentileBucket(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        typed_value = str(value)
-        obj = str.__new__(cls, typed_value)
-        obj._name_ = typed_value
-        obj._value_ = typed_value
-        cls._value2member_map_[typed_value] = obj
+        if not isinstance(value, str):
+            raise ValueError(f'{value!r} is not a valid {cls.__name__}')
+        obj = str.__new__(cls, value)
+        obj._name_ = value
+        obj._value_ = value
+        cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/rare_device_percentile_bucket.py
+++ b/fingerprint_server_sdk/models/rare_device_percentile_bucket.py
@@ -44,7 +44,7 @@ class RareDevicePercentileBucket(str, Enum):
         if not isinstance(value, str):
             raise ValueError(f'{value!r} is not a valid {cls.__name__}')
         obj = str.__new__(cls, value)
-        obj._name_ = value
+        obj._name_ = str(value)
         obj._value_ = value
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/rule_action_type.py
+++ b/fingerprint_server_sdk/models/rule_action_type.py
@@ -37,9 +37,10 @@ class RuleActionType(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        typed_value = str(value)
-        obj = str.__new__(cls, typed_value)
-        obj._name_ = typed_value
-        obj._value_ = typed_value
-        cls._value2member_map_[typed_value] = obj
+        if not isinstance(value, str):
+            raise ValueError(f'{value!r} is not a valid {cls.__name__}')
+        obj = str.__new__(cls, value)
+        obj._name_ = value
+        obj._value_ = value
+        cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/rule_action_type.py
+++ b/fingerprint_server_sdk/models/rule_action_type.py
@@ -37,7 +37,9 @@ class RuleActionType(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        obj = str.__new__(cls, value)
-        obj._name_ = str(value)
-        obj._value_ = value
+        typed_value = str(value)
+        obj = str.__new__(cls, typed_value)
+        obj._name_ = typed_value
+        obj._value_ = typed_value
+        cls._value2member_map_[typed_value] = obj
         return obj

--- a/fingerprint_server_sdk/models/rule_action_type.py
+++ b/fingerprint_server_sdk/models/rule_action_type.py
@@ -42,5 +42,6 @@ class RuleActionType(str, Enum):
         obj = str.__new__(cls, value)
         obj._name_ = str(value)
         obj._value_ = value
+        # cache it so the same value won't trigger `_missing_` again
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/rule_action_type.py
+++ b/fingerprint_server_sdk/models/rule_action_type.py
@@ -40,7 +40,7 @@ class RuleActionType(str, Enum):
         if not isinstance(value, str):
             raise ValueError(f'{value!r} is not a valid {cls.__name__}')
         obj = str.__new__(cls, value)
-        obj._name_ = value
+        obj._name_ = str(value)
         obj._value_ = value
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/rule_action_type.py
+++ b/fingerprint_server_sdk/models/rule_action_type.py
@@ -33,3 +33,11 @@ class RuleActionType(str, Enum):
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of RuleActionType from a JSON string"""
         return cls(json.loads(json_str))
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Accept unknown enum values gracefully."""
+        obj = str.__new__(cls, value)
+        obj._name_ = str(value)
+        obj._value_ = value
+        return obj

--- a/fingerprint_server_sdk/models/sdk.py
+++ b/fingerprint_server_sdk/models/sdk.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 from typing import Any, ClassVar, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing_extensions import Self
 
 from fingerprint_server_sdk.models.integration import Integration
@@ -36,11 +36,6 @@ class SDK(BaseModel):
     )
     integrations: Optional[list[Integration]] = None
     __properties: ClassVar[list[str]] = ['platform', 'version', 'integrations']
-
-    @field_validator('platform')
-    def platform_validate_enum(cls, value: Any) -> Any:
-        """Validates the enum"""
-        return value
 
     model_config = ConfigDict(
         populate_by_name=True,

--- a/fingerprint_server_sdk/models/sdk.py
+++ b/fingerprint_server_sdk/models/sdk.py
@@ -40,8 +40,6 @@ class SDK(BaseModel):
     @field_validator('platform')
     def platform_validate_enum(cls, value: Any) -> Any:
         """Validates the enum"""
-        if value not in set(['js', 'android', 'ios', 'unknown']):
-            raise ValueError("must be one of enum values ('js', 'android', 'ios', 'unknown')")
         return value
 
     model_config = ConfigDict(

--- a/fingerprint_server_sdk/models/search_events_bot.py
+++ b/fingerprint_server_sdk/models/search_events_bot.py
@@ -39,9 +39,10 @@ class SearchEventsBot(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        typed_value = str(value)
-        obj = str.__new__(cls, typed_value)
-        obj._name_ = typed_value
-        obj._value_ = typed_value
-        cls._value2member_map_[typed_value] = obj
+        if not isinstance(value, str):
+            raise ValueError(f'{value!r} is not a valid {cls.__name__}')
+        obj = str.__new__(cls, value)
+        obj._name_ = value
+        obj._value_ = value
+        cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_bot.py
+++ b/fingerprint_server_sdk/models/search_events_bot.py
@@ -44,5 +44,6 @@ class SearchEventsBot(str, Enum):
         obj = str.__new__(cls, value)
         obj._name_ = str(value)
         obj._value_ = value
+        # cache it so the same value won't trigger `_missing_` again
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_bot.py
+++ b/fingerprint_server_sdk/models/search_events_bot.py
@@ -39,7 +39,9 @@ class SearchEventsBot(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        obj = str.__new__(cls, value)
-        obj._name_ = str(value)
-        obj._value_ = value
+        typed_value = str(value)
+        obj = str.__new__(cls, typed_value)
+        obj._name_ = typed_value
+        obj._value_ = typed_value
+        cls._value2member_map_[typed_value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_bot.py
+++ b/fingerprint_server_sdk/models/search_events_bot.py
@@ -42,7 +42,7 @@ class SearchEventsBot(str, Enum):
         if not isinstance(value, str):
             raise ValueError(f'{value!r} is not a valid {cls.__name__}')
         obj = str.__new__(cls, value)
-        obj._name_ = value
+        obj._name_ = str(value)
         obj._value_ = value
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_bot.py
+++ b/fingerprint_server_sdk/models/search_events_bot.py
@@ -35,3 +35,11 @@ class SearchEventsBot(str, Enum):
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of SearchEventsBot from a JSON string"""
         return cls(json.loads(json_str))
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Accept unknown enum values gracefully."""
+        obj = str.__new__(cls, value)
+        obj._name_ = str(value)
+        obj._value_ = value
+        return obj

--- a/fingerprint_server_sdk/models/search_events_bot_info.py
+++ b/fingerprint_server_sdk/models/search_events_bot_info.py
@@ -40,7 +40,7 @@ class SearchEventsBotInfo(str, Enum):
         if not isinstance(value, str):
             raise ValueError(f'{value!r} is not a valid {cls.__name__}')
         obj = str.__new__(cls, value)
-        obj._name_ = value
+        obj._name_ = str(value)
         obj._value_ = value
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_bot_info.py
+++ b/fingerprint_server_sdk/models/search_events_bot_info.py
@@ -33,3 +33,11 @@ class SearchEventsBotInfo(str, Enum):
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of SearchEventsBotInfo from a JSON string"""
         return cls(json.loads(json_str))
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Accept unknown enum values gracefully."""
+        obj = str.__new__(cls, value)
+        obj._name_ = str(value)
+        obj._value_ = value
+        return obj

--- a/fingerprint_server_sdk/models/search_events_bot_info.py
+++ b/fingerprint_server_sdk/models/search_events_bot_info.py
@@ -42,5 +42,6 @@ class SearchEventsBotInfo(str, Enum):
         obj = str.__new__(cls, value)
         obj._name_ = str(value)
         obj._value_ = value
+        # cache it so the same value won't trigger `_missing_` again
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_bot_info.py
+++ b/fingerprint_server_sdk/models/search_events_bot_info.py
@@ -37,7 +37,9 @@ class SearchEventsBotInfo(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        obj = str.__new__(cls, value)
-        obj._name_ = str(value)
-        obj._value_ = value
+        typed_value = str(value)
+        obj = str.__new__(cls, typed_value)
+        obj._name_ = typed_value
+        obj._value_ = typed_value
+        cls._value2member_map_[typed_value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_bot_info.py
+++ b/fingerprint_server_sdk/models/search_events_bot_info.py
@@ -37,9 +37,10 @@ class SearchEventsBotInfo(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        typed_value = str(value)
-        obj = str.__new__(cls, typed_value)
-        obj._name_ = typed_value
-        obj._value_ = typed_value
-        cls._value2member_map_[typed_value] = obj
+        if not isinstance(value, str):
+            raise ValueError(f'{value!r} is not a valid {cls.__name__}')
+        obj = str.__new__(cls, value)
+        obj._name_ = value
+        obj._value_ = value
+        cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_incremental_identification_status.py
+++ b/fingerprint_server_sdk/models/search_events_incremental_identification_status.py
@@ -37,9 +37,10 @@ class SearchEventsIncrementalIdentificationStatus(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        typed_value = str(value)
-        obj = str.__new__(cls, typed_value)
-        obj._name_ = typed_value
-        obj._value_ = typed_value
-        cls._value2member_map_[typed_value] = obj
+        if not isinstance(value, str):
+            raise ValueError(f'{value!r} is not a valid {cls.__name__}')
+        obj = str.__new__(cls, value)
+        obj._name_ = value
+        obj._value_ = value
+        cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_incremental_identification_status.py
+++ b/fingerprint_server_sdk/models/search_events_incremental_identification_status.py
@@ -42,5 +42,6 @@ class SearchEventsIncrementalIdentificationStatus(str, Enum):
         obj = str.__new__(cls, value)
         obj._name_ = str(value)
         obj._value_ = value
+        # cache it so the same value won't trigger `_missing_` again
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_incremental_identification_status.py
+++ b/fingerprint_server_sdk/models/search_events_incremental_identification_status.py
@@ -37,7 +37,9 @@ class SearchEventsIncrementalIdentificationStatus(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        obj = str.__new__(cls, value)
-        obj._name_ = str(value)
-        obj._value_ = value
+        typed_value = str(value)
+        obj = str.__new__(cls, typed_value)
+        obj._name_ = typed_value
+        obj._value_ = typed_value
+        cls._value2member_map_[typed_value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_incremental_identification_status.py
+++ b/fingerprint_server_sdk/models/search_events_incremental_identification_status.py
@@ -33,3 +33,11 @@ class SearchEventsIncrementalIdentificationStatus(str, Enum):
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of SearchEventsIncrementalIdentificationStatus from a JSON string"""
         return cls(json.loads(json_str))
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Accept unknown enum values gracefully."""
+        obj = str.__new__(cls, value)
+        obj._name_ = str(value)
+        obj._value_ = value
+        return obj

--- a/fingerprint_server_sdk/models/search_events_incremental_identification_status.py
+++ b/fingerprint_server_sdk/models/search_events_incremental_identification_status.py
@@ -40,7 +40,7 @@ class SearchEventsIncrementalIdentificationStatus(str, Enum):
         if not isinstance(value, str):
             raise ValueError(f'{value!r} is not a valid {cls.__name__}')
         obj = str.__new__(cls, value)
-        obj._name_ = value
+        obj._name_ = str(value)
         obj._value_ = value
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_rare_device_percentile_bucket.py
+++ b/fingerprint_server_sdk/models/search_events_rare_device_percentile_bucket.py
@@ -41,9 +41,10 @@ class SearchEventsRareDevicePercentileBucket(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        typed_value = str(value)
-        obj = str.__new__(cls, typed_value)
-        obj._name_ = typed_value
-        obj._value_ = typed_value
-        cls._value2member_map_[typed_value] = obj
+        if not isinstance(value, str):
+            raise ValueError(f'{value!r} is not a valid {cls.__name__}')
+        obj = str.__new__(cls, value)
+        obj._name_ = value
+        obj._value_ = value
+        cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_rare_device_percentile_bucket.py
+++ b/fingerprint_server_sdk/models/search_events_rare_device_percentile_bucket.py
@@ -46,5 +46,6 @@ class SearchEventsRareDevicePercentileBucket(str, Enum):
         obj = str.__new__(cls, value)
         obj._name_ = str(value)
         obj._value_ = value
+        # cache it so the same value won't trigger `_missing_` again
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_rare_device_percentile_bucket.py
+++ b/fingerprint_server_sdk/models/search_events_rare_device_percentile_bucket.py
@@ -44,7 +44,7 @@ class SearchEventsRareDevicePercentileBucket(str, Enum):
         if not isinstance(value, str):
             raise ValueError(f'{value!r} is not a valid {cls.__name__}')
         obj = str.__new__(cls, value)
-        obj._name_ = value
+        obj._name_ = str(value)
         obj._value_ = value
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_rare_device_percentile_bucket.py
+++ b/fingerprint_server_sdk/models/search_events_rare_device_percentile_bucket.py
@@ -37,3 +37,11 @@ class SearchEventsRareDevicePercentileBucket(str, Enum):
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of SearchEventsRareDevicePercentileBucket from a JSON string"""
         return cls(json.loads(json_str))
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Accept unknown enum values gracefully."""
+        obj = str.__new__(cls, value)
+        obj._name_ = str(value)
+        obj._value_ = value
+        return obj

--- a/fingerprint_server_sdk/models/search_events_rare_device_percentile_bucket.py
+++ b/fingerprint_server_sdk/models/search_events_rare_device_percentile_bucket.py
@@ -41,7 +41,9 @@ class SearchEventsRareDevicePercentileBucket(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        obj = str.__new__(cls, value)
-        obj._name_ = str(value)
-        obj._value_ = value
+        typed_value = str(value)
+        obj = str.__new__(cls, typed_value)
+        obj._name_ = typed_value
+        obj._value_ = typed_value
+        cls._value2member_map_[typed_value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_sdk_platform.py
+++ b/fingerprint_server_sdk/models/search_events_sdk_platform.py
@@ -43,5 +43,6 @@ class SearchEventsSdkPlatform(str, Enum):
         obj = str.__new__(cls, value)
         obj._name_ = str(value)
         obj._value_ = value
+        # cache it so the same value won't trigger `_missing_` again
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_sdk_platform.py
+++ b/fingerprint_server_sdk/models/search_events_sdk_platform.py
@@ -38,7 +38,9 @@ class SearchEventsSdkPlatform(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        obj = str.__new__(cls, value)
-        obj._name_ = str(value)
-        obj._value_ = value
+        typed_value = str(value)
+        obj = str.__new__(cls, typed_value)
+        obj._name_ = typed_value
+        obj._value_ = typed_value
+        cls._value2member_map_[typed_value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_sdk_platform.py
+++ b/fingerprint_server_sdk/models/search_events_sdk_platform.py
@@ -34,3 +34,11 @@ class SearchEventsSdkPlatform(str, Enum):
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of SearchEventsSdkPlatform from a JSON string"""
         return cls(json.loads(json_str))
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Accept unknown enum values gracefully."""
+        obj = str.__new__(cls, value)
+        obj._name_ = str(value)
+        obj._value_ = value
+        return obj

--- a/fingerprint_server_sdk/models/search_events_sdk_platform.py
+++ b/fingerprint_server_sdk/models/search_events_sdk_platform.py
@@ -38,9 +38,10 @@ class SearchEventsSdkPlatform(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        typed_value = str(value)
-        obj = str.__new__(cls, typed_value)
-        obj._name_ = typed_value
-        obj._value_ = typed_value
-        cls._value2member_map_[typed_value] = obj
+        if not isinstance(value, str):
+            raise ValueError(f'{value!r} is not a valid {cls.__name__}')
+        obj = str.__new__(cls, value)
+        obj._name_ = value
+        obj._value_ = value
+        cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_sdk_platform.py
+++ b/fingerprint_server_sdk/models/search_events_sdk_platform.py
@@ -41,7 +41,7 @@ class SearchEventsSdkPlatform(str, Enum):
         if not isinstance(value, str):
             raise ValueError(f'{value!r} is not a valid {cls.__name__}')
         obj = str.__new__(cls, value)
-        obj._name_ = value
+        obj._name_ = str(value)
         obj._value_ = value
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_vpn_confidence.py
+++ b/fingerprint_server_sdk/models/search_events_vpn_confidence.py
@@ -41,7 +41,7 @@ class SearchEventsVpnConfidence(str, Enum):
         if not isinstance(value, str):
             raise ValueError(f'{value!r} is not a valid {cls.__name__}')
         obj = str.__new__(cls, value)
-        obj._name_ = value
+        obj._name_ = str(value)
         obj._value_ = value
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_vpn_confidence.py
+++ b/fingerprint_server_sdk/models/search_events_vpn_confidence.py
@@ -43,5 +43,6 @@ class SearchEventsVpnConfidence(str, Enum):
         obj = str.__new__(cls, value)
         obj._name_ = str(value)
         obj._value_ = value
+        # cache it so the same value won't trigger `_missing_` again
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_vpn_confidence.py
+++ b/fingerprint_server_sdk/models/search_events_vpn_confidence.py
@@ -38,9 +38,10 @@ class SearchEventsVpnConfidence(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        typed_value = str(value)
-        obj = str.__new__(cls, typed_value)
-        obj._name_ = typed_value
-        obj._value_ = typed_value
-        cls._value2member_map_[typed_value] = obj
+        if not isinstance(value, str):
+            raise ValueError(f'{value!r} is not a valid {cls.__name__}')
+        obj = str.__new__(cls, value)
+        obj._name_ = value
+        obj._value_ = value
+        cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/search_events_vpn_confidence.py
+++ b/fingerprint_server_sdk/models/search_events_vpn_confidence.py
@@ -34,3 +34,11 @@ class SearchEventsVpnConfidence(str, Enum):
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of SearchEventsVpnConfidence from a JSON string"""
         return cls(json.loads(json_str))
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Accept unknown enum values gracefully."""
+        obj = str.__new__(cls, value)
+        obj._name_ = str(value)
+        obj._value_ = value
+        return obj

--- a/fingerprint_server_sdk/models/search_events_vpn_confidence.py
+++ b/fingerprint_server_sdk/models/search_events_vpn_confidence.py
@@ -38,7 +38,9 @@ class SearchEventsVpnConfidence(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        obj = str.__new__(cls, value)
-        obj._name_ = str(value)
-        obj._value_ = value
+        typed_value = str(value)
+        obj = str.__new__(cls, typed_value)
+        obj._name_ = typed_value
+        obj._value_ = typed_value
+        cls._value2member_map_[typed_value] = obj
         return obj

--- a/fingerprint_server_sdk/models/tampering_confidence.py
+++ b/fingerprint_server_sdk/models/tampering_confidence.py
@@ -38,9 +38,10 @@ class TamperingConfidence(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        typed_value = str(value)
-        obj = str.__new__(cls, typed_value)
-        obj._name_ = typed_value
-        obj._value_ = typed_value
-        cls._value2member_map_[typed_value] = obj
+        if not isinstance(value, str):
+            raise ValueError(f'{value!r} is not a valid {cls.__name__}')
+        obj = str.__new__(cls, value)
+        obj._name_ = value
+        obj._value_ = value
+        cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/tampering_confidence.py
+++ b/fingerprint_server_sdk/models/tampering_confidence.py
@@ -34,3 +34,11 @@ class TamperingConfidence(str, Enum):
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of TamperingConfidence from a JSON string"""
         return cls(json.loads(json_str))
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Accept unknown enum values gracefully."""
+        obj = str.__new__(cls, value)
+        obj._name_ = str(value)
+        obj._value_ = value
+        return obj

--- a/fingerprint_server_sdk/models/tampering_confidence.py
+++ b/fingerprint_server_sdk/models/tampering_confidence.py
@@ -41,7 +41,7 @@ class TamperingConfidence(str, Enum):
         if not isinstance(value, str):
             raise ValueError(f'{value!r} is not a valid {cls.__name__}')
         obj = str.__new__(cls, value)
-        obj._name_ = value
+        obj._name_ = str(value)
         obj._value_ = value
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/tampering_confidence.py
+++ b/fingerprint_server_sdk/models/tampering_confidence.py
@@ -38,7 +38,9 @@ class TamperingConfidence(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        obj = str.__new__(cls, value)
-        obj._name_ = str(value)
-        obj._value_ = value
+        typed_value = str(value)
+        obj = str.__new__(cls, typed_value)
+        obj._name_ = typed_value
+        obj._value_ = typed_value
+        cls._value2member_map_[typed_value] = obj
         return obj

--- a/fingerprint_server_sdk/models/tampering_confidence.py
+++ b/fingerprint_server_sdk/models/tampering_confidence.py
@@ -43,5 +43,6 @@ class TamperingConfidence(str, Enum):
         obj = str.__new__(cls, value)
         obj._name_ = str(value)
         obj._value_ = value
+        # cache it so the same value won't trigger `_missing_` again
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/vpn_confidence.py
+++ b/fingerprint_server_sdk/models/vpn_confidence.py
@@ -38,9 +38,10 @@ class VpnConfidence(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        typed_value = str(value)
-        obj = str.__new__(cls, typed_value)
-        obj._name_ = typed_value
-        obj._value_ = typed_value
-        cls._value2member_map_[typed_value] = obj
+        if not isinstance(value, str):
+            raise ValueError(f'{value!r} is not a valid {cls.__name__}')
+        obj = str.__new__(cls, value)
+        obj._name_ = value
+        obj._value_ = value
+        cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/vpn_confidence.py
+++ b/fingerprint_server_sdk/models/vpn_confidence.py
@@ -43,5 +43,6 @@ class VpnConfidence(str, Enum):
         obj = str.__new__(cls, value)
         obj._name_ = str(value)
         obj._value_ = value
+        # cache it so the same value won't trigger `_missing_` again
         cls._value2member_map_[value] = obj
         return obj

--- a/fingerprint_server_sdk/models/vpn_confidence.py
+++ b/fingerprint_server_sdk/models/vpn_confidence.py
@@ -34,3 +34,11 @@ class VpnConfidence(str, Enum):
     def from_json(cls, json_str: str) -> Self:
         """Create an instance of VpnConfidence from a JSON string"""
         return cls(json.loads(json_str))
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Accept unknown enum values gracefully."""
+        obj = str.__new__(cls, value)
+        obj._name_ = str(value)
+        obj._value_ = value
+        return obj

--- a/fingerprint_server_sdk/models/vpn_confidence.py
+++ b/fingerprint_server_sdk/models/vpn_confidence.py
@@ -38,7 +38,9 @@ class VpnConfidence(str, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        obj = str.__new__(cls, value)
-        obj._name_ = str(value)
-        obj._value_ = value
+        typed_value = str(value)
+        obj = str.__new__(cls, typed_value)
+        obj._name_ = typed_value
+        obj._value_ = typed_value
+        cls._value2member_map_[typed_value] = obj
         return obj

--- a/fingerprint_server_sdk/models/vpn_confidence.py
+++ b/fingerprint_server_sdk/models/vpn_confidence.py
@@ -41,7 +41,7 @@ class VpnConfidence(str, Enum):
         if not isinstance(value, str):
             raise ValueError(f'{value!r} is not a valid {cls.__name__}')
         obj = str.__new__(cls, value)
-        obj._name_ = value
+        obj._name_ = str(value)
         obj._value_ = value
         cls._value2member_map_[value] = obj
         return obj

--- a/template/api_client.mustache
+++ b/template/api_client.mustache
@@ -793,14 +793,8 @@ class ApiClient:
         """
         try:
             return klass(data)
-        except ValueError as err:
-            raise ApiException(
-                status=0,
-                reason=(
-                    "Failed to parse `{0}` as `{1}`"
-                    .format(data, klass)
-                )
-            ) from err
+        except ValueError:
+            return data
 
     def __deserialize_model(self, data: Any, klass: Any) -> Any:
         """Deserializes list or dict to model.

--- a/template/api_client.mustache
+++ b/template/api_client.mustache
@@ -791,7 +791,16 @@ class ApiClient:
         :param klass: class literal.
         :return: enum value.
         """
-        return klass(data)
+        try:
+            return klass(data)
+        except ValueError as err:
+            raise ApiException(
+                status=0,
+                reason=(
+                    "Failed to parse `{0}` as `{1}`"
+                    .format(data, klass)
+                )
+            ) from err
 
     def __deserialize_model(self, data: Any, klass: Any) -> Any:
         """Deserializes list or dict to model.

--- a/template/api_client.mustache
+++ b/template/api_client.mustache
@@ -784,17 +784,14 @@ class ApiClient:
                 )
             ) from err
 
-    def __deserialize_enum(self, data: Any, klass: type[Enum]) -> Union[Enum, str]:
+    def __deserialize_enum(self, data: Any, klass: type[Enum]) -> Enum:
         """Deserializes primitive type to enum.
 
         :param data: primitive type.
         :param klass: class literal.
-        :return: enum value or raw string if the value is unknown.
+        :return: enum value.
         """
-        try:
-            return klass(data)
-        except ValueError:
-            return str(data)
+        return klass(data)
 
     def __deserialize_model(self, data: Any, klass: Any) -> Any:
         """Deserializes list or dict to model.

--- a/template/api_client.mustache
+++ b/template/api_client.mustache
@@ -784,17 +784,17 @@ class ApiClient:
                 )
             ) from err
 
-    def __deserialize_enum(self, data: Any, klass: type[Enum]) -> Enum:
+    def __deserialize_enum(self, data: Any, klass: type[Enum]) -> Union[Enum, str]:
         """Deserializes primitive type to enum.
 
         :param data: primitive type.
         :param klass: class literal.
-        :return: enum value.
+        :return: enum value or raw string if the value is unknown.
         """
         try:
             return klass(data)
         except ValueError:
-            return data
+            return str(data)
 
     def __deserialize_model(self, data: Any, klass: Any) -> Any:
         """Deserializes list or dict to model.

--- a/template/model_enum.mustache
+++ b/template/model_enum.mustache
@@ -1,0 +1,35 @@
+from __future__ import annotations
+import json
+from enum import Enum
+{{#vendorExtensions.x-py-other-imports}}
+{{{.}}}
+{{/vendorExtensions.x-py-other-imports}}
+from typing_extensions import Self
+
+
+class {{classname}}({{vendorExtensions.x-py-enum-type}}, Enum):
+    """
+    {{{description}}}{{^description}}{{{classname}}}{{/description}}
+    """
+
+    """
+    allowed enum values
+    """
+{{#allowableValues}}
+    {{#enumVars}}
+    {{{name}}} = {{{value}}}
+    {{/enumVars}}
+
+    @classmethod
+    def from_json(cls, json_str: str) -> Self:
+        """Create an instance of {{classname}} from a JSON string"""
+        return cls(json.loads(json_str))
+
+    @classmethod
+    def _missing_(cls, value: object) -> Self:
+        """Accept unknown enum values gracefully."""
+        obj = {{vendorExtensions.x-py-enum-type}}.__new__(cls, value)
+        obj._name_ = str(value)
+        obj._value_ = value
+        return obj
+{{/allowableValues}}

--- a/template/model_enum.mustache
+++ b/template/model_enum.mustache
@@ -31,7 +31,7 @@ class {{classname}}({{vendorExtensions.x-py-enum-type}}, Enum):
         if not isinstance(value, {{vendorExtensions.x-py-enum-type}}):
             raise ValueError(f"{value!r} is not a valid {cls.__name__}")
         obj = {{vendorExtensions.x-py-enum-type}}.__new__(cls, value)
-        obj._name_ = value
+        obj._name_ = str(value)
         obj._value_ = value
         cls._value2member_map_[value] = obj
         return obj

--- a/template/model_enum.mustache
+++ b/template/model_enum.mustache
@@ -33,6 +33,7 @@ class {{classname}}({{vendorExtensions.x-py-enum-type}}, Enum):
         obj = {{vendorExtensions.x-py-enum-type}}.__new__(cls, value)
         obj._name_ = str(value)
         obj._value_ = value
+        # cache it so the same value won't trigger `_missing_` again
         cls._value2member_map_[value] = obj
         return obj
 {{/allowableValues}}

--- a/template/model_enum.mustache
+++ b/template/model_enum.mustache
@@ -28,8 +28,10 @@ class {{classname}}({{vendorExtensions.x-py-enum-type}}, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        obj = {{vendorExtensions.x-py-enum-type}}.__new__(cls, value)
-        obj._name_ = str(value)
-        obj._value_ = value
+        typed_value = {{vendorExtensions.x-py-enum-type}}(value)
+        obj = {{vendorExtensions.x-py-enum-type}}.__new__(cls, typed_value)
+        obj._name_ = typed_value
+        obj._value_ = typed_value
+        cls._value2member_map_[typed_value] = obj
         return obj
 {{/allowableValues}}

--- a/template/model_enum.mustache
+++ b/template/model_enum.mustache
@@ -28,10 +28,11 @@ class {{classname}}({{vendorExtensions.x-py-enum-type}}, Enum):
     @classmethod
     def _missing_(cls, value: object) -> Self:
         """Accept unknown enum values gracefully."""
-        typed_value = {{vendorExtensions.x-py-enum-type}}(value)
-        obj = {{vendorExtensions.x-py-enum-type}}.__new__(cls, typed_value)
-        obj._name_ = typed_value
-        obj._value_ = typed_value
-        cls._value2member_map_[typed_value] = obj
+        if not isinstance(value, {{vendorExtensions.x-py-enum-type}}):
+            raise ValueError(f"{value!r} is not a valid {cls.__name__}")
+        obj = {{vendorExtensions.x-py-enum-type}}.__new__(cls, value)
+        obj._name_ = value
+        obj._value_ = value
+        cls._value2member_map_[value] = obj
         return obj
 {{/allowableValues}}

--- a/template/model_generic.mustache
+++ b/template/model_generic.mustache
@@ -59,25 +59,6 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
             raise ValueError(r"must validate the regular expression {{{vendorExtensions.x-pattern}}}")
         return value
     {{/vendorExtensions.x-regex}}
-    {{#isEnum}}
-
-    @field_validator('{{{name}}}')
-    def {{{name}}}_validate_enum(cls, value: Any) -> Any:
-        """Validates the enum"""
-        {{^required}}
-        if value is None:
-            return value
-
-        {{/required}}
-        {{#required}}
-        {{#isNullable}}
-        if value is None:
-            return value
-
-        {{/isNullable}}
-        {{/required}}
-        return value
-    {{/isEnum}}
 {{/vars}}
 
     model_config = ConfigDict(

--- a/template/model_generic.mustache
+++ b/template/model_generic.mustache
@@ -76,22 +76,6 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
 
         {{/isNullable}}
         {{/required}}
-        {{#isContainer}}
-        {{#isArray}}
-        for i in value:
-            if i not in set([{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}]):
-                raise ValueError("each list item must be one of ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}})")
-        {{/isArray}}
-        {{#isMap}}
-        for i in value.values():
-            if i not in set([{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}]):
-                raise ValueError("dict values must be one of enum values ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}})")
-        {{/isMap}}
-        {{/isContainer}}
-        {{^isContainer}}
-        if value not in set([{{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}}]):
-            raise ValueError("must be one of enum values ({{#allowableValues}}{{#enumVars}}{{{value}}}{{^-last}}, {{/-last}}{{/enumVars}}{{/allowableValues}})")
-        {{/isContainer}}
         return value
     {{/isEnum}}
 {{/vars}}

--- a/test/test_unknown_enum_values.py
+++ b/test/test_unknown_enum_values.py
@@ -1,0 +1,145 @@
+import json
+import unittest
+from pathlib import Path
+from typing import Any
+
+from fingerprint_server_sdk import Event
+from fingerprint_server_sdk.models.bot_info import BotInfo
+from fingerprint_server_sdk.models.proxy_details import ProxyDetails
+from fingerprint_server_sdk.models.sdk import SDK
+
+MOCK_DIR = Path(__file__).resolve().parent / 'mocks'
+
+
+class TestUnknownEnumValues(unittest.TestCase):
+    """Test that unknown/new enum values are accepted without errors."""
+
+    def _load_event_json(self) -> dict[str, Any]:
+        mock_file = MOCK_DIR / 'events' / 'get_event_200.json'
+        return json.loads(mock_file.read_text(encoding='utf-8'))
+
+    def test_event_with_unknown_proxy_type(self) -> None:
+        """Unknown proxy_type value should be accepted and preserved."""
+        data = self._load_event_json()
+        data['proxy_details']['proxy_type'] = 'unknown-value'
+
+        event = Event.from_json(json.dumps(data))
+        self.assertIsInstance(event, Event)
+        self.assertEqual(event.proxy_details.proxy_type, 'unknown-value')
+
+    def test_event_with_unknown_sdk_platform(self) -> None:
+        """Unknown SDK platform value should be accepted and preserved."""
+        data = self._load_event_json()
+        data['sdk']['platform'] = 'new-platform'
+
+        event = Event.from_json(json.dumps(data))
+        self.assertIsInstance(event, Event)
+        self.assertEqual(event.sdk.platform, 'new-platform')
+
+    def test_event_with_unknown_bot_result(self) -> None:
+        """Unknown bot result value should be accepted and preserved."""
+        data = self._load_event_json()
+        data['bot'] = 'unknown-value'
+
+        event = Event.from_json(json.dumps(data))
+        self.assertIsInstance(event, Event)
+        self.assertEqual(event.bot, 'unknown-value')
+
+    def test_event_with_unknown_vpn_confidence(self) -> None:
+        """Unknown vpn_confidence value should be accepted and preserved."""
+        data = self._load_event_json()
+        data['vpn'] = True
+        data['vpn_confidence'] = 'unknown-value'
+
+        event = Event.from_json(json.dumps(data))
+        self.assertIsInstance(event, Event)
+        self.assertEqual(event.vpn_confidence, 'unknown-value')
+
+    def test_event_with_unknown_proxy_confidence(self) -> None:
+        """Unknown proxy_confidence value should be accepted and preserved."""
+        data = self._load_event_json()
+        data['proxy_confidence'] = 'unknown-value'
+
+        event = Event.from_json(json.dumps(data))
+        self.assertIsInstance(event, Event)
+        self.assertEqual(event.proxy_confidence, 'unknown-value')
+
+    def test_event_with_unknown_tampering_confidence(self) -> None:
+        """Unknown tampering_confidence value should be accepted and preserved."""
+        data = self._load_event_json()
+        data['tampering_confidence'] = 'unknown-value'
+
+        event = Event.from_json(json.dumps(data))
+        self.assertIsInstance(event, Event)
+        self.assertEqual(event.tampering_confidence, 'unknown-value')
+
+    def test_event_with_unknown_rare_device_percentile_bucket(self) -> None:
+        """Unknown rare_device_percentile_bucket value should be accepted and preserved."""
+        data = self._load_event_json()
+        data['rare_device_percentile_bucket'] = 'unknown-value'
+
+        event = Event.from_json(json.dumps(data))
+        self.assertIsInstance(event, Event)
+        self.assertEqual(event.rare_device_percentile_bucket, 'unknown-value')
+
+    def test_proxy_details_with_unknown_proxy_type(self) -> None:
+        """ProxyDetails model should accept unknown proxy_type directly."""
+        details = ProxyDetails.from_dict({'proxy_type': 'unknown-value', 'last_seen_at': 123})
+        self.assertIsInstance(details, ProxyDetails)
+        self.assertEqual(details.proxy_type, 'unknown-value')
+
+    def test_sdk_with_unknown_platform(self) -> None:
+        """SDK model should accept unknown platform directly."""
+        sdk = SDK.from_dict({'platform': 'unknown-value', 'version': '1.0.0'})
+        self.assertIsInstance(sdk, SDK)
+        self.assertEqual(sdk.platform, 'unknown-value')
+
+    def test_bot_info_with_unknown_identity_and_confidence(self) -> None:
+        """BotInfo model should accept unknown identity and confidence values."""
+        info = BotInfo.from_dict(
+            {
+                'category': 'crawler',
+                'provider': 'TestBot',
+                'name': 'test',
+                'identity': 'unknown-value',
+                'confidence': 'unknown-value',
+            }
+        )
+        self.assertIsInstance(info, BotInfo)
+        self.assertEqual(info.identity, 'unknown-value')
+        self.assertEqual(info.confidence, 'unknown-value')
+
+    def test_event_with_multiple_unknown_enum_values(self) -> None:
+        """Event should deserialize when multiple enum fields have unknown values."""
+        data = self._load_event_json()
+        data['proxy_details']['proxy_type'] = 'unknown-value'
+        data['sdk']['platform'] = 'unknown-value'
+        data['bot'] = 'unknown-value'
+        data['vpn'] = True
+        data['vpn_confidence'] = 'unknown-value'
+        data['proxy_confidence'] = 'unknown-value'
+        data['tampering_confidence'] = 'unknown-value'
+        data['rare_device_percentile_bucket'] = 'unknown-value'
+
+        event = Event.from_json(json.dumps(data))
+        self.assertIsInstance(event, Event)
+        self.assertEqual(event.proxy_details.proxy_type, 'unknown-value')
+        self.assertEqual(event.sdk.platform, 'unknown-value')
+        self.assertEqual(event.bot, 'unknown-value')
+        self.assertEqual(event.vpn_confidence, 'unknown-value')
+        self.assertEqual(event.proxy_confidence, 'unknown-value')
+        self.assertEqual(event.tampering_confidence, 'unknown-value')
+        self.assertEqual(event.rare_device_percentile_bucket, 'unknown-value')
+
+    def test_known_enum_values_still_work(self) -> None:
+        """Known enum values should continue to work as before."""
+        data = self._load_event_json()
+
+        event = Event.from_json(json.dumps(data))
+        self.assertIsInstance(event, Event)
+        self.assertEqual(event.proxy_details.proxy_type, 'residential')
+        self.assertEqual(event.sdk.platform, 'js')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

When the API introduces new enum values (e.g., a new proxy type), the SDK threw `ValidationError` during deserialization instead of accepting the value gracefully