### PR TITLE
INTER-2269: Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/coverage-diff.yml
+++ b/.github/workflows/coverage-diff.yml
@@ -8,7 +8,7 @@ jobs:
   coverage-diff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
@@ -20,7 +20,7 @@ jobs:
           uv run coverage run --source=fingerprint_server_sdk -m pytest
           uv run coverage xml
       - name: Get Cover
-        uses: orgoro/coverage@3f13a558c5af7376496aa4848bf0224aead366ac
+        uses: orgoro/coverage@ca0c362dc1a4f100447309405e6dfea47e251495 # v3.3.1
         with:
           coverageFile: ./coverage.xml
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -11,7 +11,7 @@ jobs:
   coverage-report:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
@@ -27,13 +27,13 @@ jobs:
           rm ./htmlcov/.gitignore
 
       - name: Create Coverage Badges
-        uses: jaywcjlove/coverage-badges-cli@e07f25709cd25486855c1ba1b26da53576ff3620
+        uses: jaywcjlove/coverage-badges-cli@998665f7962b1a3935ba8c3e786171a99436e5d1 # v2.3.0
         with:
           source: coverage-summary.json
           output: htmlcov/badges.svg
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@8817a56e5bfec6e2b08345c81f4d422db53a2cdc
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           branch: gh-pages
           folder: htmlcov

--- a/.github/workflows/functional_tests.yml
+++ b/.github/workflows/functional_tests.yml
@@ -25,7 +25,7 @@ jobs:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.11" ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,13 +21,13 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         if: github.event_name == 'release'
         with:
           ref: ${{ github.event.release.tag_name }}
 
       - name: 'Checkout repository'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         if: github.event_name == 'workflow_dispatch'
         with:
           ref: ${{ github.event.inputs.tag }}
@@ -41,7 +41,7 @@ jobs:
         run: uv build
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
   e2e-tests:
     needs: publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.11" ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true


### PR DESCRIPTION
## Summary

Update all third-party GitHub Actions to their latest versions.

| Action | Previous | Updated | Notes |
|--------|----------|---------|-------|
| `actions/checkout` | v4 | v7 | Node.js 24 runtime upgrade |
| `pypa/gh-action-pypi-publish` | v1.12.4 | v1.14.0 | `verbose` and `print-hash` now on by default. Includes security fix ([GHSA-vxmw-7h4f-hqxh](https://github.com/advisories/GHSA-vxmw-7h4f-hqxh)) |
| `JamesIves/github-pages-deploy-action` | v4.3.3 | v4.8.0 | Migrated to Node.js 24 runtime |
| `jaywcjlove/coverage-badges-cli` | v1.0.11 | v2.3.0 | Minor badge generation updates |
| `orgoro/coverage` | v3.2 | v3.3.1 | Default comment title changed from "Python Coverage" to "Code Coverage". Node.js 24 runtime |
