### PR TITLE
chore: add `packageManager` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,5 +6,6 @@
     "@changesets/cli": "^2.27.8",
     "@fingerprintjs/changesets-changelog-format": "^0.2.0",
     "@fingerprintjs/commit-lint-dx-team": "^0.1.0"
-  }
+  },
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }


### PR DESCRIPTION
- Pin package manager to a specific pnpm version