### PR TITLE
Fix coverage badge generation

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           source: coverage-summary.json
           output: htmlcov/badges.svg
+          jsonPath: total.statements.pct
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0


### PR DESCRIPTION
Fixes the input default value of the `jaywcjlove/coverage-badges-cli`